### PR TITLE
(SIMP-6096) Add tasks for domain management

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 ---
 fixtures:
   repositories:
+    ruby_task_helper: https://github.com/puppetlabs/puppetlabs-ruby_task_helper
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,6 @@
+* Tue Feb 05 2019 Nick Miller <nick.miller@onyxpoint.com> - 0.0.2
+- Added Puppet Tasks for joining and leaving a domain
+- Fix bug where ntp-server wasn't passed in client install
+
 * Thu May 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1
 - Initial release of the simp_ipa module

--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ The ``simp_ipa`` class is a just a placeholder for now.
 (provided you have DNS set up correctly) or manually set all the parameters
 required. See the reference material for further documentation.
 
+### Tasks
+
+Join a domain using `ipa-client-install`:
+
+```shell
+bolt task run simp_ipa::join --nodes <nodes> server=ipa.example.com options='--verbose --mkhomedir'
+```
+
+Other options can be added to the `options` parameter, like
+`options='--mkhomedir --verbose'`.
+
+Leave a domain:
+
+```shell
+bolt task run simp_ipa::leave --nodes <nodes> domain=<domain> options='--verbose'
+```
+
+Tasks are also available from the [Puppet Enterprise console](https://puppet.com/docs/pe/2018.1/running_tasks.html).
+
+
 ## Development
 
 Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,11 @@ _Private Classes_
 
 * `simp_ipa::client::packages`: Class to contain packages required for simp::simp_ipa::install
 
+**Tasks**
+
+* [`join`](#join): Join nodes to an IPA domain
+* [`leave`](#leave): Leave an IPA domain
+
 ## Classes
 
 ### simp_ipa
@@ -149,4 +154,76 @@ Data type: `Optional[Array[Simplib::Host]]`
 
 
 Default value: `undef`
+
+## Tasks
+
+### join
+
+Join nodes to an IPA domain
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `server`
+
+Data type: `Simplib::Host`
+
+The IPA server to join to
+
+##### `hostname`
+
+Data type: `Optional[Simplib::Hostname]`
+
+The hostname of the node to be set
+
+##### `password`
+
+Data type: `Optional[String]`
+
+Password for authorization to the IPA server
+
+##### `principal`
+
+Data type: `Optional[String]`
+
+Kerberos principal for authorization
+
+##### `domain`
+
+Data type: `Optional[Simplib::Hostname]`
+
+IPA domain to join
+
+##### `realm`
+
+Data type: `Optional[String]`
+
+IPA kerberos realm to join
+
+##### `ip_address`
+
+Data type: `Optional[Array[Simplib::IP]]`
+
+IP address of the host, used in for creating DNS records in IPA
+
+##### `options`
+
+Data type: `Optional[String]`
+
+Other command line options from `ipa-client-install`, specified as an argument string. For example: `--verbose`
+
+### leave
+
+Leave an IPA domain
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `options`
+
+Data type: `Optional[String]`
+
+Other command line options from `ipa-client-install`, specified as an arguments string. For example: `--verbose`
 

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -94,6 +94,7 @@ class simp_ipa::client::install (
     'domain'     => $domain,
     'realm'      => $realm,
     'hostname'   => $hostname,
+    'ntp-server' => $ntp_server,
   }.delete_undef_values
 
   $_no_ac = $no_ac ? { true => { 'noac'  => undef }, default => {} }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_ipa",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "simp",
   "summary": "Puppet module for managing simp_ipa server and client",
   "license": "Apache-2.0",
@@ -18,6 +18,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs-ruby_task_helper",
+      "version_requirement": ">= 0.2.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/client/install_spec.rb
+++ b/spec/classes/client/install_spec.rb
@@ -44,6 +44,8 @@ describe 'simp_ipa::client::install' do
             '--domain=ipa.example.local',
             '--realm=IPA.EXAMPLE.LOCAL',
             '--hostname=client.ipa.example.local',
+            '--ntp-server=192.168.1.1',
+            '--ntp-server=192.168.1.2',
           ].join(' ')
           it { is_expected.to create_exec('ipa-client-install install').with_command(expected) }
         end

--- a/tasks/join.json
+++ b/tasks/join.json
@@ -2,11 +2,11 @@
   "description": "Join nodes to an IPA domain",
   "parameters": {
     "server": {
-      "description": "IPA server",
+      "description": "The IPA server to join to",
       "type": "Simplib::Host"
     },
     "hostname": {
-      "description": "Set the hostname of the node",
+      "description": "The hostname of the node to be set",
       "type": "Optional[Simplib::Hostname]"
     },
     "password": {
@@ -30,7 +30,7 @@
       "type": "Optional[Array[Simplib::IP]]"
     },
     "options": {
-      "description": "Other command line options from `ipa-client-install`, specified as an argument string",
+      "description": "Other command line options from `ipa-client-install`, specified as an argument string. For example: `--verbose`",
       "type": "Optional[String]"
     }
   },

--- a/tasks/join.json
+++ b/tasks/join.json
@@ -1,0 +1,38 @@
+{
+  "description": "Join nodes to an IPA domain",
+  "parameters": {
+    "server": {
+      "description": "IPA server",
+      "type": "Simplib::Host"
+    },
+    "hostname": {
+      "description": "Set the hostname of the node",
+      "type": "Optional[Simplib::Hostname]"
+    },
+    "password": {
+      "description": "Password for authorization to the IPA server",
+      "type": "Optional[String]"
+    },
+    "principal": {
+      "description": "Kerberos principal for authorization",
+      "type": "Optional[String]"
+    },
+    "domain": {
+      "description": "IPA domain to join",
+      "type": "Optional[Simplib::Hostname]"
+    },
+    "realm": {
+      "description": "IPA kerberos realm to join",
+      "type": "Optional[String]"
+    },
+    "ip_address": {
+      "description": "IP address of the host, used in for creating DNS records in IPA",
+      "type": "Optional[Array[Simplib::IP]]"
+    },
+    "options": {
+      "description": "Other command line options from `ipa-client-install`, specified as an argument string",
+      "type": "Optional[String]"
+    }
+  },
+  "files": ["ruby_task_helper/files/task_helper.rb"]
+}

--- a/tasks/join.rb
+++ b/tasks/join.rb
@@ -1,0 +1,44 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'open3'
+require_relative "../../ruby_task_helper/files/task_helper.rb"
+
+class IpaJoin < TaskHelper
+  def task(
+    server:     nil,
+    hostname:   nil,
+    password:   nil,
+    principal:  nil,
+    domain:     nil,
+    realm:      nil,
+    ip_address: nil,
+    options:    nil,
+    **kwargs
+  )
+
+  opts = {
+    'password'   => password,
+    'principal'  => principal,
+    'server'     => server,
+    'ip-address' => ip_address,
+    'domain'     => domain,
+    'realm'      => realm,
+    'hostname'   => hostname,
+  }.map { |k,v| v.nil? ? next : "--#{k}=#{v}" }
+
+  # interact with the system
+  stdout, stderr, status = Open3.capture3("ipa-client-install --unattended #{opts.join(' ')} #{options}")
+  raise "Failed to join domain #{stderr}" unless status.success?
+
+  # provide output
+  {
+    stdout: stdout,
+    stderr: stderr,
+    status: status
+  }
+  end
+end
+
+if __FILE__ == $0
+  IpaJoin.run
+end

--- a/tasks/leave.json
+++ b/tasks/leave.json
@@ -2,7 +2,7 @@
   "description": "Leave an IPA domain",
   "parameters": {
     "options": {
-      "description": "Other command line options from `ipa-client-install`, specified as an arguments string",
+      "description": "Other command line options from `ipa-client-install`, specified as an arguments string. For example: `--verbose`",
       "type": "Optional[String]"
     }
   },

--- a/tasks/leave.json
+++ b/tasks/leave.json
@@ -1,0 +1,10 @@
+{
+  "description": "Leave an IPA domain",
+  "parameters": {
+    "options": {
+      "description": "Other command line options from `ipa-client-install`, specified as an arguments string",
+      "type": "Optional[String]"
+    }
+  },
+  "files": ["ruby_task_helper/files/task_helper.rb"]
+}

--- a/tasks/leave.rb
+++ b/tasks/leave.rb
@@ -1,0 +1,27 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'open3'
+require_relative "../../ruby_task_helper/files/task_helper.rb"
+
+class IpaLeave < TaskHelper
+  def task(
+    options: nil,
+    **kwargs
+  )
+
+  # interact with the system
+  stdout, stderr, status = Open3.capture3("ipa-client-install --unattended --uninstall #{options}")
+  raise "Failed to join domain #{stderr}" unless status.success?
+
+  # provide output
+  {
+    stdout: stdout,
+    stderr: stderr,
+    status: status
+  }
+  end
+end
+
+if __FILE__ == $0
+  IpaLeave.run
+end


### PR DESCRIPTION
This commit adds two new Puppet tasks:
  * simp_ipa::join
  * simp_ipa::leave

These tasks should allow for joining and leaving an IPA domain using the
Bolt orchestration tool, or Puppet tasks from the PE console.

Additional bug fixes:
  * The ntp-server parameter wasn't passed to the client install command
    in the simp_ipa::client::install class

SIMP-6096 #close