### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.0.2
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Tue Feb 05 2019 Nick Miller <nick.miller@onyxpoint.com> - 0.0.2
 - Added Puppet Tasks for joining and leaving a domain
 - Fix bug where ntp-server wasn't passed in client install

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Tasks are also available from the [Puppet Enterprise console](https://puppet.com
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "puppetlabs-ruby_task_helper",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_ipa