### PR TITLE
Make ipa server optional in join task

### DIFF
--- a/tasks/join.json
+++ b/tasks/join.json
@@ -3,7 +3,7 @@
   "parameters": {
     "server": {
       "description": "The IPA server to join to",
-      "type": "Simplib::Host"
+      "type": "Optional[Simplib::Host]"
     },
     "hostname": {
       "description": "The hostname of the node to be set",


### PR DESCRIPTION
It's perfectly valid to not specify a server when doing an ipa client
install and instead relying on dns auto discovery.