### PR TITLE
(SIMP-10405) simp_ipa advertises EL8 when unsupported

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jul 30 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.1
+- Drop advertised support for EL8, as `simp_ipa::client::install` has
+  not been updated to integrate with the SIMP-managed PAM stack on EL8.
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 0.2.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_ipa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "simp",
   "summary": "Puppet module for managing simp_ipa server and client",
   "license": "Apache-2.0",
@@ -28,22 +28,19 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     }
   ],

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -4,6 +4,7 @@ test_name 'simp_ipa class'
 
 describe 'simp_ipa class' do
   let(:manifest) {
+    #FIXME This tests nothing. The simp_ipa class is empty.
     <<-EOS
       class { 'simp_ipa': }
     EOS
@@ -18,6 +19,13 @@ describe 'simp_ipa class' do
       it 'should be idempotent' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
+
+      # simp_ipa::client::install is tested somewhat in the simp-core ipa suite
+      it 'should test simp_ipa::client::install'
+
+      # tasks not yet tested
+      it 'should test join task'
+      it 'should test leave task'
     end
   end
 end


### PR DESCRIPTION
* Fixed:
  - Drop advertised support for EL8, as `simp_ipa::client::install`
    has not been updated to integrate with the SIMP-managed PAM
    stack on EL8.
* Not addressed
  * Did not change the default suite to actually do more than load
    the empty `simp_ipa` class.
    * simp_ipa::client::install is actually only tested in the 'ipa'
      suite in simp-core.
    * The 'join' and 'leave' tasks in this project are untested.
  * Did not remove EL8 from the nodesets in the acceptance tests.

SIMP-10405 #close